### PR TITLE
Clean up SEP demo loading and document scene12 controls

### DIFF
--- a/assets/js/demos/scenes/scene12.js
+++ b/assets/js/demos/scenes/scene12.js
@@ -4,6 +4,17 @@
  * This finale scene brings together elements from all previous demonstrations
  * to show how the self-emergent processor creates a harmonious system
  * where all components interact and strengthen each other.
+ *
+ * Keyboard Controls:
+ *   - `1-6` select between All Systems, SEP Core, Neural Connections,
+ *     Vector Dynamics, Emergent Patterns and Quantum Harmonics.
+ *   - `Space` triggers an energy pulse from the core.
+ *
+ * Module Structure:
+ *   Scene12 exports a class which orchestrates particle, neural network,
+ *   vector field and wave subsystems.  It receives framework utilities
+ *   such as Physics, MathLib, EventManager, StateManager and RenderPipeline
+ *   during construction.
  */
 
 import InteractiveController from '../controllers/interactive-controller.js';

--- a/integrate/sep-demos-page.html
+++ b/integrate/sep-demos-page.html
@@ -1210,7 +1210,7 @@
             initPiDemo();
             
             // Initialize remaining demos with placeholder canvases
-            const remainingCanvases = ['prime-canvas', 'flock-canvas', 'sep-canvas', 'fluid-canvas', 'options-canvas', 'meta-canvas'];
+            const remainingCanvases = ['prime-canvas', 'flock-canvas', 'sep-canvas', 'fluid-canvas', 'options-canvas'];
             remainingCanvases.forEach(id => {
                 const canvas = document.getElementById(id);
                 const ctx = canvas.getContext('2d');


### PR DESCRIPTION
## Summary
- drop meta-canvas placeholder from demo loader
- document keyboard controls and module structure in `scene12.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878a7b189e0832abe9655a1e16d254e