### PR TITLE
Fix intensity handling in scene1

### DIFF
--- a/assets/js/demos/scenes/scene1.js
+++ b/assets/js/demos/scenes/scene1.js
@@ -37,7 +37,7 @@ export default class Scene1 {
         this.frequency = 3; // Default frequency value
         this.interference = 'Constructive';
         this.waveValues = [];
-        this.waveAmplitude = this.settings.intensity || 50;
+        this.waveAmplitude = this.settings.intensity ?? 50;
         this.spectrum = null; // Fourier Transform results
         
         // Interactive controller (initialized in init)
@@ -80,7 +80,7 @@ export default class Scene1 {
         this.waveValues = new Array(this.canvas.width).fill(0);
         this.frequency = 3;
         this.wavePhaseOffsets = [0, Math.PI / 3, 2 * Math.PI / 3];
-        this.waveAmplitude = this.settings.intensity || 50;
+        this.waveAmplitude = this.settings.intensity ?? 50;
         this.spectrum = null;
     }
     
@@ -214,7 +214,7 @@ export default class Scene1 {
         this.lastTime = timestamp;
         
         // Use generic settings from the framework's control panel
-        this.waveAmplitude = this.settings.intensity || 50;
+        this.waveAmplitude = this.settings.intensity ?? 50;
         const speed = this.settings.speed || 1.0;
         
         // Update scene state


### PR DESCRIPTION
## Summary
- allow zero intensity levels in the wave interference demo (scene1)

## Testing
- `node _sep/testbed/qbsa.test.mjs`
- `node _sep/testbed/scene10_fluid.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_6878bcf2f63c832aa5eb4fa7acfb4811