### PR TITLE
Fix demo 3 reset

### DIFF
--- a/integrate/sep-demos-page.html
+++ b/integrate/sep-demos-page.html
@@ -761,6 +761,8 @@
             let impactAngle = 45;
             
             function drawBilliards() {
+                // Ensure local reference reflects any external resets
+                balls = animations.billiard.balls || balls;
                 ctx.fillStyle = '#0f0f0f';
                 ctx.fillRect(0, 0, canvas.width, canvas.height);
                 
@@ -848,7 +850,7 @@
             }
             
             drawBilliards();
-            animations.billiard = { draw: drawBilliards, isPlaying };
+            animations.billiard = { draw: drawBilliards, isPlaying, balls };
         }
         
         function resetBilliards() {


### PR DESCRIPTION
## Summary
- hook billiard demo state into the global animations object
- keep the balls list in sync when resetting the demo

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6878bcff2f20832aa2788bcec4fdb217