### PR TITLE
Enable demo 2

### DIFF
--- a/_sep/testbed/scene2_enable_check.js
+++ b/_sep/testbed/scene2_enable_check.js
@@ -1,0 +1,8 @@
+import { SCENES, STATUS } from "../../assets/js/demos/config/scene-registry.js";
+const scene = SCENES[2];
+if (scene.status === STATUS.READY) {
+  console.log('Scene 2 is ready');
+} else {
+  console.error('Scene 2 not ready:', scene.status);
+  process.exit(1);
+}

--- a/assets/js/demos/config/scene-registry.js
+++ b/assets/js/demos/config/scene-registry.js
@@ -63,7 +63,7 @@ export const SCENES = {
         name: "Identity Through Distinction",
         description: "Euclid's Angle Classification System",
         longDescription: "Interactive protractor with dynamic angle measurement. Drag vectors to create angles and observe real-time classification as acute, right, or obtuse with corresponding cosine values.",
-        status: STATUS.IN_PROGRESS,
+        status: STATUS.READY,
         type: 'boundary',
         color: SCENE_COLORS.BOUNDARY,
         demoName: DEMO_NAMES.ANGLE_CLASSIFICATION,


### PR DESCRIPTION
## Summary
- mark scene 2 as ready in the demo registry
- add a small testbed script to verify scene 2 status

## Testing
- `node _sep/testbed/scene2_enable_check.js`

------
https://chatgpt.com/codex/tasks/task_e_6878bcf9adec832ab3c542dbf74b67a4