### PR TITLE
Fix demo 5 draw parameter

### DIFF
--- a/_sep/testbed/scene5_gravity.test.mjs
+++ b/_sep/testbed/scene5_gravity.test.mjs
@@ -1,0 +1,30 @@
+import Scene5 from '../../assets/js/demos/scenes/scene5.js';
+
+const canvas = {
+  width: 100,
+  height: 100,
+  addEventListener() {},
+  removeEventListener() {}
+};
+
+function createCtx() {
+  const noop = () => {};
+  const gradient = { addColorStop: noop };
+  return new Proxy({
+    createRadialGradient: () => gradient
+  }, {
+    get(target, prop) {
+      if (!(prop in target)) {
+        target[prop] = noop;
+      }
+      return target[prop];
+    }
+  });
+}
+
+const ctx = createCtx();
+const scene = new Scene5(canvas, ctx, { speed: 1, intensity: 50 }, null, null, null, null, null);
+scene.controller = { updateInfoPanel() {}, render() {} };
+scene.reset();
+scene.animate(0);
+console.log('scene5 gravity basic test passed');

--- a/assets/js/demos/scenes/scene5.js
+++ b/assets/js/demos/scenes/scene5.js
@@ -368,7 +368,7 @@ export default class Scene5 {
         this.update(deltaTime * this.settings.speed);
         
         // Render the scene
-        this.draw();
+        this.draw(timestamp);
     }
 
     /**
@@ -443,8 +443,9 @@ export default class Scene5 {
 
     /**
      * Draw the scene - handles both normal and video modes
+     * @param {number} timestamp - The current timestamp from requestAnimationFrame
      */
-    draw() {
+    draw(timestamp) {
         // Clear canvas with semi-transparent background for trail effect
         this.ctx.fillStyle = `rgba(10, 10, 10, ${this.showTrails ? 0.15 : 1.0})`;
         this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);


### PR DESCRIPTION
## Summary
- fix undefined `timestamp` in scene5 draw routine
- add basic test for scene5 gravity demo

## Testing
- `node _sep/testbed/qbsa.test.mjs`
- `node _sep/testbed/scene10_fluid.test.mjs`
- `node _sep/testbed/scene5_gravity.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_6878bd08c970832aa7173c3ab9bf88ee