### PR TITLE
Enable scene selection from URL

### DIFF
--- a/assets/js/demos/app-loader.js
+++ b/assets/js/demos/app-loader.js
@@ -50,10 +50,22 @@ async function initializeApp() {
             canvas.height = appContainer.clientHeight;
         }
         
+        // Determine initial scene from query string
+        const params = new URLSearchParams(window.location.search);
+        const sceneParam = params.get('scene');
+        let initialScene = DEFAULT_SCENE;
+
+        if (sceneParam) {
+            const match = Object.values(SCENE_IDS).find(id => id.toString() === sceneParam);
+            if (match) {
+                initialScene = match;
+            }
+        }
+
         // Initialize the framework
         const app = new AppFramework(canvas, {
             autoStart: true,
-            defaultScene: DEFAULT_SCENE,
+            defaultScene: initialScene,
             debug: false,
             recordingEnabled: true,
             persistState: true


### PR DESCRIPTION
## Summary
- parse `scene` query param on page load
- use the specified scene when initializing the framework

## Testing
- `for f in _sep/testbed/*.test.mjs; do node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_687a86e235c8832a884d23d2e3c99e14