### PR TITLE
Add scene constants for loader

### DIFF
--- a/assets/js/demos/config/scene-registry.js
+++ b/assets/js/demos/config/scene-registry.js
@@ -35,6 +35,22 @@ export const DEMO_NAMES = {
     META_VISUALIZATION: 'Meta Visualization'
 };
 
+// Mapping of human-readable keys to scene IDs
+export const SCENE_IDS = {
+    THE_HIDDEN_CODE: 1,
+    IDENTITY_THROUGH_DISTINCTION: 2,
+    COSINE_ALIGNMENT: 3,
+    SINE_DEVIATION: 4,
+    ANGLE_REALITY_CLASSIFICATION: 5,
+    BOUNDARY_ENFORCEMENT: 6,
+    PRIME_UNIQUENESS: 7,
+    MULTI_PERSPECTIVE_COHERENCE: 8,
+    SEP_OPERATIONALIZATION: 9,
+    PARTICLE_FLUID: 10,
+    DERIVATIVE_APPLICATIONS: 11,
+    REALITYS_CODE: 12
+};
+
 // Complete scene registry
 export const SCENES = {
     1: { 
@@ -299,3 +315,9 @@ export const VIDEO_SEQUENCE = Object.values(SCENES).map(scene => ({
     focusPoints: scene.videoSequence.focusPoints,
     preset: 'demo'
 }));
+
+// Array of all scene definitions for easy iteration
+export const ALL_SCENES = Object.values(SCENES);
+
+// Default scene to load when the app starts
+export const DEFAULT_SCENE = SCENE_IDS.THE_HIDDEN_CODE;


### PR DESCRIPTION
## Summary
- define `SCENE_IDS` as human-readable scene identifiers
- expose `ALL_SCENES` and `DEFAULT_SCENE`

## Testing
- `node _sep/testbed/qbsa.test.mjs`
- `node _sep/testbed/scene5_gravity.test.mjs`
- `node _sep/testbed/scene10_fluid.test.mjs`
- `node _sep/testbed/lava-lamp.test.mjs`
- `node _sep/testbed/scene6_block_size.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_687a86e17088832ab1534d95c454ad9d