### PR TITLE
Add InteractiveController for Scene 12

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>SEP Demo</title>
+    <link rel="stylesheet" href="assets/css/demos.css">
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
+        }
+        canvas { display: block; width: 100%; height: 100%; }
+    </style>
+</head>
+<body class="demo-hub">
+    <canvas id="demo-canvas"></canvas>
+    <script type="module" src="assets/js/demos/app-loader.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- integrate `InteractiveController` into scene12
- expose subsystem toggles through new custom controls
- skip updates/draws for disabled subsystems
- add demo.html for running the generic application

## Testing
- `node _sep/testbed/lava-lamp.test.mjs && node _sep/testbed/qbsa.test.mjs && node _sep/testbed/scene5_gravity.test.mjs && node _sep/testbed/scene6_block_size.test.mjs && node _sep/testbed/scene10_fluid.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_687a86ef35b0832a81421d3b0470c90c