### PR TITLE
Refactor scene6 with InteractiveController

### DIFF
--- a/_sep/testbed/scene6_block_size.test.mjs
+++ b/_sep/testbed/scene6_block_size.test.mjs
@@ -11,8 +11,9 @@ const canvas = {
 const ctx = { fillStyle:'', fillRect(){}, beginPath(){}, moveTo(){}, lineTo(){}, stroke(){}, fill(){}, arc(){}, closePath(){}, strokeRect(){}, fillText(){}, textAlign:'', font:'', setLineDash() {} };
 
 global.window = { addEventListener() {}, removeEventListener() {} };
+const eventManager = { on() { return () => {}; } };
 
-const scene = new Scene6(canvas, ctx, { speed: 1, intensity: 50 });
+const scene = new Scene6(canvas, ctx, { speed: 1, intensity: 50 }, eventManager, null, null);
 await scene.init();
 scene.handleMouseMove({ clientX: 100, clientY: 160 });
 scene.handleMouseClick({ clientX: 100, clientY: 160 });


### PR DESCRIPTION
## Summary
- integrate `InteractiveController` with scene6
- initialize controller and route mouse/keyboard events through `EventManager`
- add custom controls for noise level, coherence threshold and view mode
- provide helper `cycleViewMode` and cleanup routines
- adjust testbed for new constructor

## Testing
- `node _sep/testbed/scene5_gravity.test.mjs`
- `node _sep/testbed/scene6_block_size.test.mjs`
- `node _sep/testbed/lava-lamp.test.mjs`
- `node _sep/testbed/scene10_fluid.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_687a86e83cc8832a905aebb484c67e65